### PR TITLE
Add rustbgpd target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-# Created by venv; see https://docs.python.org/3/library/venv.html
-*
+.venv/
+venv/
+__pycache__/
+*.csv
+*.png

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ to create prefixes and send them. These are pretty lightweight, so it's easy to 
 of neighbors with a small amount (hundreds or thousands) or prefixes. BIRD is generally faster, so it is the default
 but EXABGP is around for some extra testing.
 
+### Row-local runtime provenance and diagnostics
+
+Each newly created benchmark row writes `runtime-manifest.json` atomically in
+its configuration directory after the monitor, testers, and local target have
+been created. Every entry records the instance role, exact container name and
+ID, configured image and Docker-resolved image ID, attached network name and
+ID, and absolute host directory. The file is row-local evidence of the actual
+runtime objects. Use its Docker-returned identities instead of guessing fixed
+container names, and its per-entry host directories instead of a global `/tmp`
+log glob. Every row creates fresh tester instances; container reuse is unsupported because it
+cannot prove this provenance.
+
+Tester error and timeout counts are also row-local. Each tester reads only log
+files directly inside its own host directory, and the benchmark sums every
+actual tester instance. BIRD connection-collision and `NEXT_HOP` messages are
+expected diagnostics and do not increment the error count; other matching
+diagnostics remain visible in the output statistics.
+
 The second way to generate traffic is by playing back MRT files using [bgpdump2](https://github.com/rtbrick/bgpdump2). 
 This is much faster, and is good for playing back internet size tables.  [RouteViews](http://archive.routeviews.org/)
 is a good place to get MRT files to play back.

--- a/base.py
+++ b/base.py
@@ -210,11 +210,17 @@ class Container(object):
         t.start()
 
     def neighbor_stats(self, queue):
+        # Use a dedicated Docker client so long-running exec calls
+        # (e.g. 60s+ gRPC queries under load) don't block the shared
+        # connection pool used by the monitor and stats threads.
+        from settings import Client
+        neighbor_dckr = Client(version='auto')
+
         def stats():
             while True:
                 if self.stop_monitoring:
                     return
-                neighbors_received_full, neighbors_checked = self.get_neighbor_received_routes()
+                neighbors_received_full, neighbors_checked = self.get_neighbor_received_routes(dckr_override=neighbor_dckr)
                 queue.put({'who': self.name, 'neighbors_checked': neighbors_checked})
                 queue.put({'who': self.name, 'neighbors_received_full': neighbors_received_full})
                 time.sleep(1)
@@ -223,9 +229,10 @@ class Container(object):
         t.daemon = True
         t.start()
 
-    def local(self, cmd, stream=False, detach=False, stderr=False):
-        i = dckr.exec_create(container=self.name, cmd=cmd, stderr=stderr)
-        return dckr.exec_start(i['Id'], stream=stream, detach=detach)
+    def local(self, cmd, stream=False, detach=False, stderr=False, dckr_override=None):
+        d = dckr_override or dckr
+        i = d.exec_create(container=self.name, cmd=cmd, stderr=stderr)
+        return d.exec_start(i['Id'], stream=stream, detach=detach)
 
     def get_startup_cmd(self):
         raise NotImplementedError()
@@ -262,26 +269,30 @@ class Container(object):
                 neighbors_checked[n] = False
         return tester_count, neighbors_checked
 
-    def get_neighbor_received_routes(self):
-        ## if we ccall this before the daemon starts we will not get output
-        
+    def get_neighbor_received_routes(self, dckr_override=None):
+        ## if we call this before the daemon starts we will not get output
+
         tester_count, neighbors_checked = self.get_test_counts()
         neighbors_received_full = neighbors_checked.copy()
-        neighbors_received, neighbors_accepted = self.get_neighbors_state()
-        for n in neighbors_accepted.keys():
+        neighbors_received, neighbors_accepted = self.get_neighbors_state(dckr_override=dckr_override)
 
+        # get_neighbors_state returns (None, None) on query failure.
+        # Propagate that as-is so callers can distinguish "query failed"
+        # from "zero neighbors."
+        if neighbors_received is None or neighbors_accepted is None:
+            return neighbors_received_full, neighbors_checked
+
+        for n in neighbors_accepted.keys():
             #this will include the monitor, we don't want to check that
-            if n in tester_count and neighbors_accepted[n] >= tester_count[n]: 
+            if n in tester_count and neighbors_accepted[n] >= tester_count[n]:
                 neighbors_checked[n] = True
 
-        
         for n in neighbors_received.keys():
-
             #this will include the monitor, we don't want to check that
-            if (n in tester_count and neighbors_received[n] >= tester_count[n]) or neighbors_received[n] == True: 
+            if (n in tester_count and neighbors_received[n] >= tester_count[n]) or neighbors_received[n] == True:
                 neighbors_received_full[n] = True
 
-        return neighbors_received_full, neighbors_checked 
+        return neighbors_received_full, neighbors_checked
 
 class Target(Container):
 

--- a/base.py
+++ b/base.py
@@ -115,6 +115,13 @@ class Container(object):
                                     detach=True, name=self.name,
                                     stdin_open=True, volumes=self.volumes, host_config=host_config)
         self.ctn_id = ctn['Id']
+        inspected = dckr.inspect_container(self.ctn_id)
+        runtime_name = inspected.get('Name', '').lstrip('/')
+        runtime_image = inspected.get('Image')
+        if not runtime_name or not runtime_image:
+            raise RuntimeError('created container is missing inspected Name or Image')
+        self.name = runtime_name
+        self.image_id = runtime_image
 
         ipv4_addresses = self.get_ipv4_addresses()
 
@@ -157,6 +164,8 @@ class Container(object):
             return
 
         dckr.connect_container_to_network(self.ctn_id, net_id, ipv4_address=ipv4_addresses[0])
+        self.network_name = dckr_net_name
+        self.network_id = net_id
         dckr.start(container=self.name)
 
         if len(ipv4_addresses) > 1:
@@ -333,6 +342,7 @@ class Tester(Container):
     CONTAINER_NAME_PREFIX = None
 
     def __init__(self, name, host_dir, conf, image):
+        self.configured_name = name
         Container.__init__(self, self.CONTAINER_NAME_PREFIX + name, image, host_dir, self.GUEST_DIR, conf)
 
     def get_ipv4_addresses(self):
@@ -380,8 +390,29 @@ class Tester(Container):
 
         return None
 
-    def find_errors():
-        return 0
+    def count_log_lines(self, required, excluded=()):
+        """Count matching evidence in this tester instance's own log files."""
+        required = tuple(value.lower() for value in required)
+        excluded = tuple(value.lower() for value in excluded)
+        matches = 0
 
-    def find_timeouts():
-        return 0
+        if not os.path.isdir(self.host_dir):
+            return matches
+
+        for entry in os.scandir(self.host_dir):
+            if not entry.is_file(follow_symlinks=False) or not entry.name.endswith('.log'):
+                continue
+            with open(entry.path, encoding='utf-8', errors='replace') as log:
+                for line in log:
+                    lowered = line.lower()
+                    if (all(value in lowered for value in required)
+                            and not any(value in lowered for value in excluded)):
+                        matches += 1
+
+        return matches
+
+    def find_errors(self):
+        return self.count_log_lines(('error',))
+
+    def find_timeouts(self):
+        return self.count_log_lines(('timeout',))

--- a/bgpdump2.py
+++ b/bgpdump2.py
@@ -1,5 +1,4 @@
 import re
-from subprocess import check_output, Popen, PIPE
 from base import *
 from mrt_tester import MRTTester
 
@@ -108,14 +107,8 @@ ulimit -n 65536
         return startup
 #> {}/bgpdump2.log 2>&1 
 
-    def find_errors():
-        grep1 = Popen(('grep -i error /tmp/bgperf2/mrt-injector*/*.log'), shell=True, stdout=PIPE)
-        errors = check_output(('wc', '-l'), stdin=grep1.stdout)
-        grep1.wait()
-        return errors.decode('utf-8').strip()
+    def find_errors(self):
+        return self.count_log_lines(('error',))
 
-    def find_timeouts():
-        grep1 = Popen(('grep -i timeout /tmp/bgperf2/mrt-injector*/*.log'), shell=True, stdout=PIPE)
-        timeouts = check_output(('wc', '-l'), stdin=grep1.stdout)
-        grep1.wait()
-        return timeouts.decode('utf-8').strip()
+    def find_timeouts(self):
+        return self.count_log_lines(('timeout',))

--- a/bgperf2.py
+++ b/bgperf2.py
@@ -563,7 +563,7 @@ def bench(args):
                     o_s = finish_bench(args, output_stats, bench_stats, bench_start,target, m, fail=True) 
                     return o_s
 
-            elif (last_neighbors_checked > 0 or neighbors_received_full > 0) and recved == last_recved:
+            elif (last_neighbors_checked > 0 or neighbors_received_full > 0 or neighbors_checkpoint) and recved == last_recved:
                 last_recved_count +=1
             else:
                 last_recved = recved
@@ -571,7 +571,13 @@ def bench(args):
 
             if neighbors_checked != last_neighbors_checked:
                 last_neighbors_checked = neighbors_checked
-                last_recved_count = 0
+                # Only reset the stabilization counter if the monitor hasn't
+                # already confirmed convergence.  At high scale the neighbor
+                # query can return after a long block, changing
+                # neighbors_checked and resetting the counter indefinitely,
+                # which hangs the run.
+                if not neighbors_checkpoint:
+                    last_recved_count = 0
 
             if elapsed.seconds > 0:
                 rm_line()
@@ -588,6 +594,13 @@ def bench(args):
             if recved > 0 and output_stats['first_received_time'] == start - start:
                 output_stats['first_received_time'] = elapsed
 
+            # The monitor-observed route count is the ground truth for
+            # convergence.  The per-neighbor query (via CLI/gRPC) can be
+            # blocked or slow while the target is under heavy load.  If the
+            # monitor has received enough prefixes, treat the neighbors
+            # checkpoint as met.
+            if recved >= output_stats['required'] and not neighbors_checkpoint:
+                neighbors_checkpoint = True
 
             # we are trying to discover if the tests have finished
             #  in the ieal world, we'd know how many prefixes were sent and we'd just check for that
@@ -629,7 +642,7 @@ def bench(args):
                 bench_prefix = f"{args.target}_{args.tester_type}_{args.prefix_num}_{args.neighbor_num}"
                 create_bench_graphs(bench_stats, prefix=bench_prefix)       
 
-            if elapsed.seconds > 15 and recved_checkpoint == 0 and last_recved_count == 0 and recved == 0:
+            if elapsed.seconds > 120 and recved_checkpoint == 0 and last_recved_count == 0 and recved == 0:
                 last_recved_count = 1_000_000 # make it artifically high so things fail quickly
 
         # Too many of the same counts in a row, not progressing

--- a/bgperf2.py
+++ b/bgperf2.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import argparse
+import json
 import os
 import sys
 import yaml
@@ -79,6 +80,50 @@ def gc_thresh3():
     gc_thresh3 = '/proc/sys/net/ipv4/neigh/default/gc_thresh3'
     with open(gc_thresh3) as f:
         return int(f.read().strip())
+
+
+def collect_tester_diagnostics(testers):
+    return {
+        'errors': sum(tester.find_errors() for tester in testers),
+        'timeouts': sum(tester.find_timeouts() for tester in testers),
+    }
+
+
+def write_runtime_manifest(config_dir, instances):
+    """Atomically retain the identities of the containers used by one row."""
+    records = []
+    container_names = set()
+    container_ids = set()
+
+    for role, instance in instances:
+        container_id = getattr(instance, 'ctn_id', None)
+        if not container_id:
+            raise RuntimeError('runtime manifest instance has no container ID: {0}'.format(instance.name))
+        if instance.name in container_names or container_id in container_ids:
+            raise RuntimeError('runtime manifest contains a duplicate container identity')
+        container_names.add(instance.name)
+        container_ids.add(container_id)
+        records.append({
+            'role': role,
+            'configured_name': getattr(instance, 'configured_name', None),
+            'container_name': instance.name,
+            'container_id': container_id,
+            'configured_image': instance.image,
+            'image_id': instance.image_id,
+            'network_name': instance.network_name,
+            'network_id': instance.network_id,
+            'host_dir': os.path.abspath(instance.host_dir),
+        })
+
+    manifest_path = os.path.join(config_dir, 'runtime-manifest.json')
+    temporary_path = manifest_path + '.tmp'
+    with open(temporary_path, 'w', encoding='utf-8') as manifest_file:
+        json.dump({'instances': records}, manifest_file, indent=2, sort_keys=True)
+        manifest_file.write('\n')
+        manifest_file.flush()
+        os.fsync(manifest_file.fileno())
+    os.replace(temporary_path, manifest_path)
+    return manifest_path
 
 
 def doctor(args):
@@ -217,17 +262,19 @@ def controller_memory_free(queue):
 stop_monitoring = False
 
 def bench(args):
+    if 'repeat' in vars(args):
+        raise ValueError('repeat mode is unsupported; run a fresh row with new tester instances')
+
     output_stats = {}
     config_dir = '{0}/{1}'.format(args.dir, args.bench_name)
     dckr_net_name = args.docker_network_name or args.bench_name + '-br'
     
     remove_target_containers()
 
-    if not args.repeat:
-        remove_old_containers()
+    remove_old_containers()
 
-        if os.path.exists(config_dir):
-            shutil.rmtree(config_dir, ignore_errors=True)
+    if os.path.exists(config_dir):
+        shutil.rmtree(config_dir, ignore_errors=True)
 
     bench_start = time.time()
     if args.file:
@@ -271,71 +318,70 @@ def bench(args):
     # this is the order
     testers = []
     mrt_injector = None
-    if not args.repeat:
-        valid_indexes = None
-        asns = None
-        for idx, tester in enumerate(conf['testers']):
-            if 'name' not in tester:
-                name = 'tester{0}'.format(idx)
+    valid_indexes = None
+    asns = None
+    for idx, tester in enumerate(conf['testers']):
+        if 'name' not in tester:
+            name = 'tester{0}'.format(idx)
+        else:
+            name = tester['name']
+        if not 'type' in tester:
+            tester_type = 'bird'
+        else:
+            tester_type = tester['type']
+        if tester_type == 'exa':
+            tester_class = ExaBGPTester
+        elif tester_type == 'bird':
+            tester_class = BIRDTester
+        elif tester_type == 'mrt':
+            if 'mrt_injector' not in tester:
+                mrt_injector = 'gobgp'
             else:
-                name = tester['name']
-            if not 'type' in tester:
-                tester_type = 'bird'
+                mrt_injector = tester['mrt_injector']
+            if mrt_injector == 'gobgp':
+                tester_class = GoBGPMRTTester
+            elif mrt_injector == 'exabgp':
+                tester_class = ExaBGPMrtTester
+            elif mrt_injector == 'bgpdump2':
+                tester_class = Bgpdump2Tester
             else:
-                tester_type = tester['type']
-            if tester_type == 'exa':
-                tester_class = ExaBGPTester
-            elif tester_type == 'bird':
-                tester_class = BIRDTester
-            elif tester_type == 'mrt':
-                if 'mrt_injector' not in tester:
-                    mrt_injector = 'gobgp'
-                else:
-                    mrt_injector = tester['mrt_injector']
-                if mrt_injector == 'gobgp':
-                    tester_class = GoBGPMRTTester
-                elif mrt_injector == 'exabgp':
-                    tester_class = ExaBGPMrtTester
-                elif mrt_injector == 'bgpdump2':
-                    tester_class = Bgpdump2Tester
-                else:
-                    print('invalid mrt_injector:', mrt_injector)
-                    sys.exit(1)
-
-            else:
-                print('invalid tester type:', tester_type)
+                print('invalid mrt_injector:', mrt_injector)
                 sys.exit(1)
 
-
-            t = tester_class(name, config_dir+'/'+name, tester)
-            if not mrt_injector:
-                print('run tester', name, 'type', tester_type)
-            else:
-                print('run tester', name, 'type', tester_type, mrt_injector)
-            if idx > 0:
-                rm_line()
-            t.run(conf['target'], dckr_net_name)
-            testers.append(t)
+        else:
+            print('invalid tester type:', tester_type)
+            sys.exit(1)
 
 
-            # have to do some extra stuff with bgpdump2
-            #  because it's sending real data, we need to figure out
-            #  wich neighbor has data and what the actual ASN is
-            if tester_type == 'mrt' and mrt_injector == 'bgpdump2' and not valid_indexes:
-                print("finding asns and such from mrt file")
-                valid_indexes = t.get_index_valid(args.prefix_num)
-                asns = t.get_index_asns()
+        t = tester_class(name, config_dir+'/'+name, tester)
+        if not mrt_injector:
+            print('run tester', name, 'type', tester_type)
+        else:
+            print('run tester', name, 'type', tester_type, mrt_injector)
+        if idx > 0:
+            rm_line()
+        t.run(conf['target'], dckr_net_name)
+        testers.append(t)
 
-                for test in conf['testers']:
-                    test['bgpdump-index'] = valid_indexes[test['mrt-index'] % len(valid_indexes)]
-                    neighbor = next(iter(test['neighbors'].values()))
-                    neighbor['as'] = asns[test['bgpdump-index']]
 
-                # TODO: this needs to all be moved to it's own object and file
-                #  so this stuff isn't copied around
-                str_conf = gen_mako_macro() + yaml.dump(conf, default_flow_style=False)
-                with open('{0}/scenario.yaml'.format(config_dir), 'w') as f:
-                    f.write(str_conf)
+        # have to do some extra stuff with bgpdump2
+        #  because it's sending real data, we need to figure out
+        #  wich neighbor has data and what the actual ASN is
+        if tester_type == 'mrt' and mrt_injector == 'bgpdump2' and not valid_indexes:
+            print("finding asns and such from mrt file")
+            valid_indexes = t.get_index_valid(args.prefix_num)
+            asns = t.get_index_asns()
+
+            for test in conf['testers']:
+                test['bgpdump-index'] = valid_indexes[test['mrt-index'] % len(valid_indexes)]
+                neighbor = next(iter(test['neighbors'].values()))
+                neighbor['as'] = asns[test['bgpdump-index']]
+
+            # TODO: this needs to all be moved to it's own object and file
+            #  so this stuff isn't copied around
+            str_conf = gen_mako_macro() + yaml.dump(conf, default_flow_style=False)
+            with open('{0}/scenario.yaml'.format(config_dir), 'w') as f:
+                f.write(str_conf)
 
     is_remote = True if 'remote' in conf['target'] and conf['target']['remote'] else False
 
@@ -462,6 +508,15 @@ def bench(args):
             target = target_class('{0}/{1}'.format(config_dir, args.target), conf['target'])
         target.run(conf, dckr_net_name)
 
+    runtime_instances = [('monitor', m)]
+    runtime_instances.extend(('tester', tester) for tester in testers)
+    if not is_remote:
+        runtime_instances.append(('target', target))
+    write_runtime_manifest(
+        config_dir,
+        runtime_instances,
+    )
+
     time.sleep(1)
 
     output_stats['monitor_wait_time'] = m.wait_established(conf['target']['local-address'])
@@ -563,8 +618,9 @@ def bench(args):
                     output_stats['recved'] = recved
                     f.close() if f else None
                     output_stats['fail_msg'] = f"FAILED: dropping received count {recved} neighbors_checked {neighbors_checked}"
-                    output_stats['tester_errors'] = tester_class.find_errors() 
-                    output_stats['tester_timeouts'] = tester_class.find_timeouts()      
+                    tester_diagnostics = collect_tester_diagnostics(testers)
+                    output_stats['tester_errors'] = tester_diagnostics['errors']
+                    output_stats['tester_timeouts'] = tester_diagnostics['timeouts']
                     print("FAILED")
                     o_s = finish_bench(args, output_stats, bench_stats, bench_start,target, m, fail=True) 
                     return o_s
@@ -628,8 +684,9 @@ def bench(args):
 
             if neighbors_checkpoint and last_recved_count >=time_for_assurance:
                 output_stats['recved']= recved       
-                output_stats['tester_errors'] = tester_class.find_errors() 
-                output_stats['tester_timeouts'] = tester_class.find_timeouts() 
+                tester_diagnostics = collect_tester_diagnostics(testers)
+                output_stats['tester_errors'] = tester_diagnostics['errors']
+                output_stats['tester_timeouts'] = tester_diagnostics['timeouts']
                 
                 f.close() if f else None
     
@@ -658,8 +715,9 @@ def bench(args):
             output_stats['recved']= recved          
             f.close() if f else None
             output_stats['fail_msg'] = f"FAILED: stuck received count {recved} neighbors_checked {neighbors_checked}"
-            output_stats['tester_errors'] = tester_class.find_errors()
-            output_stats['tester_timeouts'] = tester_class.find_timeouts() 
+            tester_diagnostics = collect_tester_diagnostics(testers)
+            output_stats['tester_errors'] = tester_diagnostics['errors']
+            output_stats['tester_timeouts'] = tester_diagnostics['timeouts']
             print("FAILED")
             o_s = finish_bench(args, output_stats,bench_stats, bench_start,target, m, fail=True)  
             return o_s
@@ -803,6 +861,14 @@ def batch(args):
         batch_config = yaml.safe_load(f)
 
     for test in batch_config['tests']:
+        for target in test['targets']:
+            if 'repeat' in target:
+                raise ValueError(
+                    "batch test '{0}' target '{1}' uses removed repeat mode; "
+                    'run fresh tester instances'.format(test['name'], target['name'])
+                )
+
+    for test in batch_config['tests']:
         results = []
         for n in test['neighbors']:
             for p in test['prefixes']:
@@ -818,8 +884,8 @@ def batch(args):
                         a.filter_test = filter if filter != 'None' else None
                         # read any config attribute that was specified in the yaml batch file
                         a.local_address_prefix = t['local_address_prefix'] if 'local_address_prefix' in t else '10.10.0.0/16'
-                        for field in ['single_table', 'docker_network_name', 'repeat', 'file', 'target_local_address',
-                                        'label', 'target_local_address', 'monitor_local_address', 'target_router_id',
+                        for field in ['single_table', 'docker_network_name', 'file', 'target_local_address',
+                                        'label', 'monitor_local_address', 'target_router_id',
                                         'monitor_router_id', 'target_config_file', 'filter_type','mrt_injector', 'mrt_file',
                                         'tester_type', 'license_file']:
                             setattr(a, field, t[field]) if field in t else setattr(a, field, None)
@@ -1118,7 +1184,6 @@ def create_args_parser(main=True):
                               'determine the Linux bridge name starting from '
                               'the Docker network name in case of tests of '
                               'remote targets.')
-    parser_bench.add_argument('-r', '--repeat', action='store_true', help='use existing tester/monitor container')
     parser_bench.add_argument('-f', '--file', metavar='CONFIG_FILE')
     parser_bench.add_argument('-o', '--output', metavar='STAT_FILE')
     add_gen_conf_args(parser_bench)

--- a/bgperf2.py
+++ b/bgperf2.py
@@ -41,6 +41,7 @@ from bird import BIRD, BIRDTarget
 from frr import FRRouting, FRRoutingTarget
 from frr_compiled import FRRoutingCompiled, FRRoutingCompiledTarget
 from rustybgp import RustyBGP, RustyBGPTarget
+from rustbgpd import RustBGPd, RustBGPdTarget
 from openbgp import OpenBGP, OpenBGPTarget
 from flock import Flock, FlockTarget
 from srlinux import SRLinux, SRLinuxTarget
@@ -96,7 +97,7 @@ def doctor(args):
     else:
         print('... not found. run `bgperf prepare`')
 
-    for name in ['gobgp', 'bird', 'frr_c', 'rustybgp', 'openbgp', 'flock', 'srlinux']:
+    for name in ['gobgp', 'bird', 'frr_c', 'rustybgp', 'rustbgpd', 'openbgp', 'flock', 'srlinux']:
         print('{0} image'.format(name), end=' ')
         if img_exists('bgperf/{0}'.format(name)):
             print('... ok')
@@ -113,6 +114,7 @@ def prepare(args):
     BIRD.build_image(args.force, nocache=args.no_cache)
     #FRRouting.build_image(args.force,  nocache=args.no_cache)
     RustyBGP.build_image(args.force, nocache=args.no_cache)
+    RustBGPd.build_image(args.force, nocache=args.no_cache)
     OpenBGP.build_image(args.force, nocache=args.no_cache)
     FRRoutingCompiled.build_image(args.force, nocache=args.no_cache)
     Bgpdump2.build_image(args.force, nocache=args.no_cache)
@@ -133,6 +135,8 @@ def update(args):
         FRRouting.build_image(True, checkout=args.checkout, nocache=args.no_cache)
     if args.image == 'all' or args.image == 'rustybgp':
         RustyBGP.build_image(True, checkout=args.checkout, nocache=args.no_cache)
+    if args.image == 'all' or args.image == 'rustbgpd':
+        RustBGPd.build_image(True, checkout=args.checkout, nocache=args.no_cache)
     if args.image == 'all' or args.image == 'openbgp':
         OpenBGP.build_image(True, checkout=args.checkout, nocache=args.no_cache)
     if args.image == 'all' or args.image == 'flock':
@@ -146,7 +150,7 @@ def update(args):
 
 def remove_target_containers():
     for target_class in [BIRDTarget, GoBGPTarget, FRRoutingTarget, FRRoutingCompiledTarget, 
-        RustyBGPTarget, OpenBGPTarget, FlockTarget, JunosTarget, SRLinuxTarget, EosTarget]:
+        RustyBGPTarget, RustBGPdTarget, OpenBGPTarget, FlockTarget, JunosTarget, SRLinuxTarget, EosTarget]:
         if ctn_exists(target_class.CONTAINER_NAME):
             print('removing target container', target_class.CONTAINER_NAME)
             dckr.remove_container(target_class.CONTAINER_NAME, force=True)
@@ -437,6 +441,8 @@ def bench(args):
             target_class = FRRoutingCompiledTarget
         elif args.target == 'rustybgp':
             target_class = RustyBGPTarget
+        elif args.target == 'rustbgpd':
+            target_class = RustBGPdTarget
         elif args.target == 'openbgp':
             target_class = OpenBGPTarget
         elif args.target == 'flock':
@@ -1066,7 +1072,7 @@ def create_args_parser(main=True):
 
     parser_update = s.add_parser('update', help='rebuild bgp docker images')
     parser_update.add_argument('image', choices=['exabgp', 'exabgp_mrtparse', 'gobgp', 'bird', 'frr', 'frr_c', 
-                                'rustybgp', 'openbgp', 'flock',  'bgpdump2', 'all'])
+                                'rustybgp', 'rustbgpd', 'openbgp', 'flock',  'bgpdump2', 'all'])
     parser_update.add_argument('-c', '--checkout', default='HEAD')
     parser_update.add_argument('-n', '--no-cache', action='store_true')
     parser_update.set_defaults(func=update)
@@ -1098,8 +1104,8 @@ def create_args_parser(main=True):
         parser.add_argument('--filter_test', choices=['transit', 'ixp'], default=None)
 
     parser_bench = s.add_parser('bench', help='run benchmarks')
-    parser_bench.add_argument('-t', '--target', choices=['gobgp', 'bird',  'frr_c', 'rustybgp', 
-                              'openbgp', 'flock', 'srlinux', 'junos', 'eos'], default='bird')
+    parser_bench.add_argument('-t', '--target', choices=['gobgp', 'bird',  'frr_c', 'rustybgp',
+                              'rustbgpd', 'openbgp', 'flock', 'srlinux', 'junos', 'eos'], default='bird')
     parser_bench.add_argument('-i', '--image', help='specify custom docker image')
     parser_bench.add_argument('--mrt-file', type=str, 
                               help='mrt file, requires absolute path')

--- a/bird.py
+++ b/bird.py
@@ -218,7 +218,7 @@ return true;
         else:
             return ret.strip('\n')
 
-    def get_neighbors_state(self):
+    def get_neighbors_state(self, dckr_override=None):
         neighbors_accepted = {}
         neighbors_received = {}
         neighbor_received_output = self.local("birdc 'show protocols all'").decode('utf-8')

--- a/eos.py
+++ b/eos.py
@@ -76,7 +76,7 @@ class EosTarget(Eos, Target):
 
 
 
-    def get_neighbors_state(self):
+    def get_neighbors_state(self, dckr_override=None):
         neighbors_accepted = {}
         neighbors_received = {}
         neighbor_received_output = self.local("Cli -c 'sh ip bgp summary |json'")

--- a/flock.py
+++ b/flock.py
@@ -90,12 +90,12 @@ class FlockTarget(Flock, Target):
         i= dckr.exec_create(container=self.name, cmd=version, stderr=True)
         return dckr.exec_start(i['Id'], stream=False, detach=False).decode('utf-8').strip('\n')
 
-    def get_neighbors_state(self):
+    def get_neighbors_state(self, dckr_override=None):
         neighbors_accepted = {}
         neighbor_received_output = json.loads(self.local("/usr/bin/flockc bgp --host 127.0.0.1 -J").decode('utf-8'))
         return neighbor_received_output['neighbor_summary']['default']['recv_converged']
     
-    def get_neighbor_received_routes(self):
+    def get_neighbor_received_routes(self, dckr_override=None):
         ## if we call this before the daemon starts we will not get output
         
         tester_count, neighbors_checked = self.get_test_counts()

--- a/frr.py
+++ b/frr.py
@@ -148,7 +148,7 @@ no bgp ebgp-requires-policy
         ret = super().exec_version_cmd()
         return ret.split('\n')[0]
     
-    def get_neighbors_state(self):
+    def get_neighbors_state(self, dckr_override=None):
         neighbors_accepted = {}
         neighbors_received = {}
         neighbor_received_output = self.local("vtysh -c 'sh ip bgp summary json'")
@@ -175,10 +175,10 @@ no bgp ebgp-requires-policy
 
         return neighbors
 
-    def get_neighbor_received_routes(self):
+    def get_neighbor_received_routes(self, dckr_override=None):
         # FRR doesn't have a counter to look at to see if all the prefixes have been sent
         # instead we have to look at the log file and see if End-of-RIB has been sent for the neighbor
-        neighbors_received_full, neighbors_checked = super(FRRoutingTarget, self).get_neighbor_received_routes()
+        neighbors_received_full, neighbors_checked = super(FRRoutingTarget, self).get_neighbor_received_routes(dckr_override=dckr_override)
 
         assert(all(value == False for value in neighbors_received_full.values()))
         neighbors_received_full = self._get_EOR_from_log(neighbors_received_full)

--- a/gobgp.py
+++ b/gobgp.py
@@ -143,7 +143,7 @@ class GoBGPTarget(GoBGP, Target):
         return ret.split(' ')[2].strip('\n')
 
 
-    def get_neighbors_state(self):
+    def get_neighbors_state(self, dckr_override=None):
         neighbors_accepted = {}
         neighbors_received = {}
         neighbor_received_output = self.local("/root/gobgp neighbor -j")

--- a/junos.py
+++ b/junos.py
@@ -91,7 +91,7 @@ class JunosTarget(Junos, Target):
         return dckr.exec_start(i['Id'], stream=False, detach=False).decode('utf-8').split('\n')[3].strip('\n').split(':')[1].split(' ')[1]
 
 
-    def get_neighbors_state(self):
+    def get_neighbors_state(self, dckr_override=None):
         neighbors_accepted = {}
         neighbors_received = {}
         neighbor_received_output = json.loads(self.local("cli show bgp neighbor \| no-more \| display json").decode('utf-8'))

--- a/monitor.py
+++ b/monitor.py
@@ -63,9 +63,13 @@ gobgpd -t yaml -f {1}/{2} -l {3} > {1}/gobgpd.log 2>&1
         i = dckr.exec_create(container=self.name, cmd=cmd)
         return dckr.exec_start(i['Id'], stream=stream)
 
-    def wait_established(self, neighbor):
+    def wait_established(self, neighbor, timeout=600):
         n = 0
         while True:
+            if n > timeout:
+                raise RuntimeError(
+                    'monitor: session with {0} not established after {1} seconds; '
+                    'target is not accepting the monitor peering'.format(neighbor, timeout))
             if n > 0:
                  rm_line()
             print(f"Waiting {n} seconds for monitor")

--- a/mrt_tester.py
+++ b/mrt_tester.py
@@ -18,7 +18,6 @@ from gobgp import GoBGP
 from exabgp import ExaBGP_MRTParse
 import os
 import yaml
-from subprocess import check_output, Popen, PIPE
 from  settings import dckr
 
 from base import *
@@ -211,8 +210,5 @@ gobgpd -t yaml -f {1}/{2} -l {3} > {1}/gobgpd.log 2>&1 &
         #startup += '\n' + 'pkill -SIGHUP gobgpd'
         return startup
 
-    def find_errors():
-        grep1 = Popen(('grep -i expired /tmp/bgperf2/mrt-injector*/*.log'), shell=True, stdout=PIPE)
-        errors = check_output(('wc', '-l'), stdin=grep1.stdout)
-        grep1.wait()
-        return errors.decode('utf-8').strip()
+    def find_errors(self):
+        return self.count_log_lines(('expired',))

--- a/openbgp.py
+++ b/openbgp.py
@@ -118,7 +118,7 @@ fib-update no
         i= dckr.exec_create(container=self.name, cmd=version, stderr=True)
         return dckr.exec_start(i['Id'], stream=False, detach=False).decode('utf-8').strip('\n')
 
-    def get_neighbors_state(self):
+    def get_neighbors_state(self, dckr_override=None):
         neighbors_accepted = {}
         neighbors_received_full = {}
         neighbor_received_output = json.loads(self.local("/usr/local/sbin/bgpctl -j show neighbor").decode('utf-8'))

--- a/rustbgpd.py
+++ b/rustbgpd.py
@@ -1,0 +1,133 @@
+import json
+import os
+
+from base import *
+
+
+class RustBGPd(Container):
+    CONTAINER_NAME = None
+    GUEST_DIR = '/root/config'
+
+    def __init__(self, host_dir, conf, image='bgperf/rustbgpd'):
+        super(RustBGPd, self).__init__(self.CONTAINER_NAME, image, host_dir, self.GUEST_DIR, conf)
+
+    @classmethod
+    def build_image(cls, force=False, tag='bgperf/rustbgpd', checkout='v0.63.0', nocache=False):
+
+        cls.dockerfile = '''
+FROM rust:1.95-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+RUN git clone https://github.com/lance0/rustbgpd.git . && git checkout {0}
+RUN cargo build --release -p rustbgpd -p rustbgpctl
+
+FROM debian:bookworm-slim
+WORKDIR /root
+
+RUN apt-get update && apt-get install -y --no-install-recommends iproute2 && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/rustbgpd /usr/local/bin/rustbgpd
+COPY --from=builder /build/target/release/rbgp /usr/local/bin/rbgp
+'''.format(checkout)
+        super(RustBGPd, cls).build_image(force, tag, nocache)
+
+
+class RustBGPdTarget(RustBGPd, Target):
+
+    CONTAINER_NAME = 'bgperf_rustbgpd_target'
+    CONFIG_FILE_NAME = 'config.toml'
+
+    def write_config(self):
+        config = '[global]\n'
+        config += 'asn = {}\n'.format(self.conf['as'])
+        config += 'router_id = "{}"\n'.format(self.conf['router-id'])
+        config += 'listen_port = 179\n'
+        config += '\n'
+        config += '[global.telemetry]\n'
+        config += 'prometheus_addr = "0.0.0.0:9179"\n'
+        config += 'log_format = "json"\n'
+        config += '\n'
+        # From v0.63.0 the daemon grants implicit local-operator
+        # authorization on its owner-only default unix socket, so no
+        # gRPC security configuration is needed for local benchmarking.
+
+        # rustbgpd's durable event history is on by default and persists
+        # route events to SQLite.  Set RUSTBGPD_EVENT_HISTORY_OFF=1 to
+        # disable it and measure the daemon without that overhead.
+        if os.environ.get('RUSTBGPD_EVENT_HISTORY_OFF'):
+            config += '[event_history]\n'
+            config += 'enabled = false\n'
+            config += '\n'
+
+        neighbors = list(flatten(
+            list(t.get('neighbors', {}).values())
+            for t in self.scenario_global_conf['testers']
+        )) + [self.scenario_global_conf['monitor']]
+
+        for n in neighbors:
+            config += '[[neighbors]]\n'
+            config += 'address = "{}"\n'.format(n['local-address'])
+            config += 'remote_asn = {}\n'.format(n['as'])
+            config += '\n'
+
+        with open('{0}/{1}'.format(self.host_dir, self.CONFIG_FILE_NAME), 'w') as f:
+            f.write(config)
+
+    def get_startup_cmd(self):
+        return '\n'.join(
+            ['#!/bin/bash',
+             'ulimit -n 65536',
+             'cd {guest_dir} && exec rustbgpd {guest_dir}/{config_file_name} > {guest_dir}/rustbgpd.log 2>&1']
+        ).format(
+            guest_dir=self.guest_dir,
+            config_file_name=self.CONFIG_FILE_NAME)
+
+    def get_version_cmd(self):
+        return "rustbgpd --version"
+
+    def exec_version_cmd(self):
+        ret = super().exec_version_cmd()
+        return ret.strip()
+
+    def get_neighbors_state(self, dckr_override=None):
+        """Query neighbor state via the rbgp CLI.
+
+        Returns (neighbors_received, neighbors_accepted) dicts keyed by
+        neighbor address.  On any failure (timeout, parse error, empty
+        output) returns (None, None) so callers can distinguish "query
+        failed" from "zero neighbors."
+        """
+        import time as _time
+        t0 = _time.monotonic()
+        try:
+            output = self.local(
+                'rbgp --json neighbor',
+                dckr_override=dckr_override
+            )
+            elapsed_ms = int((_time.monotonic() - t0) * 1000)
+
+            if not output:
+                print(f'rbgp: empty output ({elapsed_ms}ms)')
+                return None, None
+
+            data = json.loads(output.decode('utf-8'))
+
+            neighbors_received = {}
+            neighbors_accepted = {}
+            for neighbor in data:
+                addr = neighbor.get('address', '')
+                received = neighbor.get('prefixes_received', 0)
+                neighbors_received[addr] = received
+                neighbors_accepted[addr] = received
+
+            if elapsed_ms > 5000:
+                print(f'rbgp: slow query ({elapsed_ms}ms)')
+
+            return neighbors_received, neighbors_accepted
+
+        except Exception as e:
+            elapsed_ms = int((_time.monotonic() - t0) * 1000)
+            print(f'rbgp: error after {elapsed_ms}ms: {e}')
+            return None, None

--- a/rustbgpd.py
+++ b/rustbgpd.py
@@ -12,7 +12,7 @@ class RustBGPd(Container):
         super(RustBGPd, self).__init__(self.CONTAINER_NAME, image, host_dir, self.GUEST_DIR, conf)
 
     @classmethod
-    def build_image(cls, force=False, tag='bgperf/rustbgpd', checkout='v0.63.0', nocache=False):
+    def build_image(cls, force=False, tag='bgperf/rustbgpd', checkout='v0.64.0', nocache=False):
 
         cls.dockerfile = '''
 FROM rust:1.95-bookworm AS builder

--- a/srlinux.py
+++ b/srlinux.py
@@ -113,13 +113,13 @@ set / network-instance default protocols bgp neighbor {0} peer-group neighbors
         return dckr.exec_start(i['Id'], stream=False, detach=False).decode('utf-8').strip('\n')
 
 
-    def get_neighbors_state(self):
+    def get_neighbors_state(self, dckr_override=None):
         neighbors_accepted = {}
         neighbor_received_output = json.loads(self.local("/usr/bin/SRLinuxc bgp --host 127.0.0.1 -J").decode('utf-8'))
 
         return neighbor_received_output['neighbor_summary']['recv_converged']
     
-    def get_neighbor_received_routes(self):
+    def get_neighbor_received_routes(self, dckr_override=None):
         ## if we call this before the daemon starts we will not get output
         
         tester_count, neighbors_checked = self.get_test_counts()

--- a/tester.py
+++ b/tester.py
@@ -16,8 +16,6 @@
 from base import Tester
 from exabgp import ExaBGP
 from bird import BIRD
-from  settings import dckr
-from subprocess import check_output, Popen, PIPE
 
 
 class ExaBGPTester(Tester, ExaBGP):
@@ -64,7 +62,7 @@ class BIRDTester(Tester, BIRD):
     CONTAINER_NAME_PREFIX = 'bgperf_bird_tester_'
 
     def __init__(self, name, host_dir, conf, image='bgperf/bird'):
-        super(BIRDTester, self).__init__('bgperf_bird_' + name, host_dir, conf, image)
+        super(BIRDTester, self).__init__(name, host_dir, conf, image)
 
     def configure_neighbors(self, target_conf):
         peers = list(self.conf.get('neighbors', {}).values())
@@ -105,10 +103,5 @@ ulimit -n 65536
             startup.append('''bird -c {0}/{1}.conf -s {0}/{1}.ctl >>{0}/{1}.log 2>&1\n'''.format(self.guest_dir, p['router-id']))
         return '\n'.join(startup)
 
-    def find_errors():
-        grep1 = Popen(('grep RMT /tmp/bgperf2/tester/*.log'), shell=True, stdout=PIPE)
-        grep2 = Popen(('grep', '-v', 'NEXT_HOP'), stdin=grep1.stdout, stdout=PIPE)
-        errors = check_output(('wc', '-l'), stdin=grep2.stdout)
-        grep1.wait()
-        grep2.wait()
-        return errors.decode('utf-8').strip()
+    def find_errors(self):
+        return self.count_log_lines(('rmt',), ('collision', 'next_hop'))

--- a/tester.py
+++ b/tester.py
@@ -81,11 +81,10 @@ protocol bgp {{
     #hold time 5;
     source address {3};
     connect delay time 1;
-    interface "eth0";
     strict bind;
     ipv4 {{ import none; export all; }};
     local {3} as {4};
-neighbor {0} as {1};
+    neighbor {0} as {1};
 }}
 protocol static {{ ipv4;
 '''.format(target_conf['local-address'], target_conf['as'],

--- a/tests/test_tester_provenance.py
+++ b/tests/test_tester_provenance.py
@@ -1,0 +1,299 @@
+import inspect
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import bgperf2
+import base
+from base import Tester
+from bgpdump2 import Bgpdump2Tester
+from mrt_tester import ExaBGPMrtTester, GoBGPMRTTester
+from tester import BIRDTester, ExaBGPTester
+
+
+class FixtureTester(Tester):
+    CONTAINER_NAME_PREFIX = 'bgperf_fixture_tester_'
+    GUEST_DIR = '/fixture'
+
+
+class FakeDocker:
+    def containers(self, **kwargs):
+        return []
+
+    def create_host_config(self, **kwargs):
+        return kwargs
+
+    def create_container(self, **kwargs):
+        return {'Id': 'container-id'}
+
+    def inspect_container(self, container_id):
+        return {'Name': '/docker-returned-name', 'Image': 'sha256:image-id'}
+
+    def networks(self, names):
+        return [{
+            'Name': names[0],
+            'Id': 'network-id',
+            'IPAM': {'Config': [{'Subnet': '10.0.0.0/24'}]},
+        }]
+
+    def connect_container_to_network(self, *args, **kwargs):
+        pass
+
+    def start(self, **kwargs):
+        pass
+
+
+class TesterProvenanceTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write_log(self, directory, name, contents):
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / name).write_text(contents, encoding='utf-8')
+
+    def test_all_tester_names_apply_their_prefix_once(self):
+        conf = {'neighbors': {}}
+        cases = (
+            (ExaBGPTester, 'bgperf_exabgp_tester_row'),
+            (BIRDTester, 'bgperf_bird_tester_row'),
+            (ExaBGPMrtTester, 'bgperf_exabgp_mrttester_row'),
+            (GoBGPMRTTester, 'bgperf_gobgp_mrttester_row'),
+            (Bgpdump2Tester, 'bgperf_bgpdump2_tester_row'),
+        )
+
+        for tester_class, expected_name in cases:
+            with self.subTest(tester_class=tester_class.__name__):
+                host_dir = self.root / tester_class.__name__
+                tester = tester_class('row', str(host_dir), conf)
+                self.assertEqual(expected_name, tester.name)
+
+    def test_base_diagnostics_are_instance_local(self):
+        own_dir = self.root / 'own'
+        sibling_dir = self.root / 'sibling'
+        tester = FixtureTester('row', str(own_dir), {'neighbors': {}}, 'fixture:image')
+        self.write_log(own_dir, 'tester.log', 'ERROR one\nTimeout one\nordinary line\n')
+        self.write_log(own_dir, 'ignored.txt', 'ERROR two\nTimeout two\n')
+        self.write_log(sibling_dir, 'tester.log', 'ERROR three\nTimeout three\n')
+
+        self.assertEqual(1, tester.find_errors())
+        self.assertEqual(1, tester.find_timeouts())
+
+    def test_bird_expected_messages_are_not_errors(self):
+        host_dir = self.root / 'bird'
+        tester = BIRDTester('row', str(host_dir), {'neighbors': {}})
+        self.write_log(
+            host_dir,
+            'bird.log',
+            '\n'.join((
+                'RMT Connection collision resolution',
+                'RMT Invalid NEXT_HOP attribute',
+                'RMT malformed attribute',
+                'RMT hold timeout',
+            )),
+        )
+
+        self.assertEqual(2, tester.find_errors())
+        self.assertEqual(1, tester.find_timeouts())
+
+    def test_mrt_and_bgpdump_diagnostics_use_their_own_rows(self):
+        gobgp_dir = self.root / 'gobgp-mrt'
+        bgpdump_dir = self.root / 'bgpdump-mrt'
+        gobgp = GoBGPMRTTester('gobgp', str(gobgp_dir), {'neighbors': {}})
+        bgpdump = Bgpdump2Tester('bgpdump', str(bgpdump_dir), {'neighbors': {}})
+        self.write_log(gobgp_dir, 'gobgpd.log', 'peer expired\nrequest timeout\n')
+        self.write_log(bgpdump_dir, 'bgpdump2.log', 'ERROR decode\nTIMEOUT connect\n')
+
+        self.assertEqual(1, gobgp.find_errors())
+        self.assertEqual(1, gobgp.find_timeouts())
+        self.assertEqual(1, bgpdump.find_errors())
+        self.assertEqual(1, bgpdump.find_timeouts())
+
+    def test_diagnostics_aggregate_every_instance(self):
+        testers = (
+            SimpleNamespace(find_errors=lambda: 1, find_timeouts=lambda: 2),
+            SimpleNamespace(find_errors=lambda: 3, find_timeouts=lambda: 4),
+        )
+        self.assertEqual(
+            {'errors': 4, 'timeouts': 6},
+            bgperf2.collect_tester_diagnostics(testers),
+        )
+
+    def test_container_run_retains_docker_returned_provenance(self):
+        host_dir = self.root / 'runtime'
+        tester = FixtureTester(
+            'row',
+            str(host_dir),
+            {'neighbors': {'peer': {'local-address': '10.0.0.2'}}},
+            'fixture:tag',
+        )
+
+        with patch.object(base, 'dckr', FakeDocker()):
+            base.Container.run(tester, 'row-br')
+
+        self.assertEqual('row', tester.configured_name)
+        self.assertEqual('docker-returned-name', tester.name)
+        self.assertEqual('container-id', tester.ctn_id)
+        self.assertEqual('sha256:image-id', tester.image_id)
+        self.assertEqual('row-br', tester.network_name)
+        self.assertEqual('network-id', tester.network_id)
+        manifest_path = bgperf2.write_runtime_manifest(
+            self.temporary_directory.name, (('tester', tester),),
+        )
+        manifest = json.loads(Path(manifest_path).read_text(encoding='utf-8'))
+        self.assertEqual('docker-returned-name', manifest['instances'][0]['container_name'])
+
+    def test_runtime_manifest_uses_actual_instance_values_atomically(self):
+        row_dir = self.root / 'row'
+        row_dir.mkdir()
+        instances = (
+            ('monitor', SimpleNamespace(
+                name='bgperf_monitor', ctn_id='monitor-id', image='monitor:image', image_id='monitor-image-id',
+                network_name='row-br', network_id='network-id',
+                host_dir=str(row_dir / 'monitor'),
+            )),
+            ('tester', SimpleNamespace(
+                name='bgperf_bird_tester_row', ctn_id='tester-id', image='tester:image', image_id='tester-image-id',
+                network_name='row-br', network_id='network-id',
+                configured_name='row',
+                host_dir=str(row_dir / 'tester'),
+            )),
+            ('target', SimpleNamespace(
+                name='bgperf_target', ctn_id='target-id', image='target:image', image_id='target-image-id',
+                network_name='row-br', network_id='network-id',
+                host_dir=str(row_dir / 'target'),
+            )),
+        )
+
+        with patch.object(bgperf2.os, 'replace', wraps=os.replace) as replace:
+            manifest_path = bgperf2.write_runtime_manifest(
+                str(row_dir), instances,
+            )
+
+        replace.assert_called_once()
+        self.assertFalse((row_dir / 'runtime-manifest.json.tmp').exists())
+        self.assertEqual(str(row_dir / 'runtime-manifest.json'), manifest_path)
+        manifest = json.loads(Path(manifest_path).read_text(encoding='utf-8'))
+        self.assertEqual(['monitor', 'tester', 'target'], [row['role'] for row in manifest['instances']])
+        self.assertEqual(
+            {
+                'container_name': 'bgperf_bird_tester_row',
+                'container_id': 'tester-id',
+                'configured_image': 'tester:image',
+                'image_id': 'tester-image-id',
+                'network_name': 'row-br',
+                'network_id': 'network-id',
+                'host_dir': str((row_dir / 'tester').resolve()),
+                'role': 'tester',
+                'configured_name': 'row',
+            },
+            manifest['instances'][1],
+        )
+
+    def test_runtime_manifest_refuses_missing_or_duplicate_identity(self):
+        row_dir = self.root / 'row'
+        row_dir.mkdir()
+        missing = SimpleNamespace(
+            name='missing', image='image', host_dir=str(row_dir / 'missing'),
+        )
+        duplicate_a = SimpleNamespace(
+            name='a', ctn_id='same-id', image='image:a', image_id='image-a-id',
+            network_name='row-br', network_id='net', host_dir=str(row_dir / 'a'),
+        )
+        duplicate_b = SimpleNamespace(
+            name='b', ctn_id='same-id', image='image:b', image_id='image-b-id',
+            network_name='row-br', network_id='net', host_dir=str(row_dir / 'b'),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, 'no container ID'):
+            bgperf2.write_runtime_manifest(str(row_dir), (('tester', missing),))
+        with self.assertRaisesRegex(RuntimeError, 'duplicate container identity'):
+            bgperf2.write_runtime_manifest(
+                str(row_dir), (('tester', duplicate_a), ('tester', duplicate_b)),
+            )
+        self.assertFalse((row_dir / 'runtime-manifest.json').exists())
+
+    def assert_bench_repeat_rejected_before_mutation(self, value):
+        run_root = self.root / 'bench'
+        args = SimpleNamespace(repeat=value, dir=str(run_root), bench_name='row')
+        with patch.object(
+            bgperf2,
+            'remove_target_containers',
+            side_effect=AssertionError('mutation reached'),
+        ) as remove:
+            with self.assertRaisesRegex(ValueError, 'run a fresh row'):
+                bgperf2.bench(args)
+        remove.assert_not_called()
+        self.assertFalse(run_root.exists())
+
+    def test_bench_rejects_repeat_true_before_mutation(self):
+        self.assert_bench_repeat_rejected_before_mutation(True)
+
+    def test_bench_rejects_repeat_false_before_mutation(self):
+        self.assert_bench_repeat_rejected_before_mutation(False)
+
+    def assert_batch_repeat_rejected_by_whole_file_preflight(self, value):
+        batch_file = self.root / 'batch.yaml'
+        batch_file.write_text(
+            'tests:\n'
+            '  - name: clean-test\n'
+            '    neighbors: [1]\n'
+            '    prefixes: [1]\n'
+            "    filter_test: ['None']\n"
+            '    targets:\n'
+            '      - name: clean-target\n'
+            '  - name: destructive-proof\n'
+            '    neighbors: [1]\n'
+            '    prefixes: [1]\n'
+            "    filter_test: ['None']\n"
+            '    targets:\n'
+            '      - name: bad-target\n'
+            '        repeat: {0}\n'.format('true' if value else 'false'),
+            encoding='utf-8',
+        )
+        args = SimpleNamespace(batch_config=str(batch_file))
+        old_cwd = os.getcwd()
+        os.chdir(self.root)
+        try:
+            with patch.object(bgperf2, 'bench', side_effect=AssertionError('row executed')) as bench:
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "test 'destructive-proof' target 'bad-target'.*fresh tester instances",
+                ):
+                    bgperf2.batch(args)
+            bench.assert_not_called()
+            self.assertFalse((self.root / 'destructive-proof.csv').exists())
+        finally:
+            os.chdir(old_cwd)
+
+    def test_batch_rejects_repeat_true_before_any_row_or_output(self):
+        self.assert_batch_repeat_rejected_by_whole_file_preflight(True)
+
+    def test_batch_rejects_repeat_false_before_any_row_or_output(self):
+        self.assert_batch_repeat_rejected_by_whole_file_preflight(False)
+
+    def test_diagnostic_methods_are_instances_without_shell_or_global_tmp(self):
+        for tester_class in (Tester, BIRDTester, GoBGPMRTTester, Bgpdump2Tester):
+            with self.subTest(tester_class=tester_class.__name__):
+                self.assertEqual(
+                    ['self'],
+                    list(inspect.signature(tester_class.find_errors).parameters),
+                )
+
+        repository = Path(__file__).resolve().parents[1]
+        for relative_path in ('base.py', 'tester.py', 'mrt_tester.py', 'bgpdump2.py'):
+            source = (repository / relative_path).read_text(encoding='utf-8')
+            self.assertNotIn('/tmp/bgperf2', source)
+            self.assertNotIn('shell=True', source)
+            self.assertNotIn('Popen', source)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds a target for rustbgpd (https://github.com/lance0/rustbgpd), a BGP daemon written in Rust, plus fixes for harness hangs found while running it at higher scale.

**rustbgpd target** (`rustbgpd.py`): builds the daemon and its `rbgp` CLI from the public repository at a pinned release tag (v0.63.0 by default; `bgperf2 update rustbgpd -c <ref>` to override), registered in prepare/update/bench/doctor. The harness reads neighbor state via the `rbgp` CLI over the daemon's default owner-only unix socket, which authorizes local clients without any gRPC security configuration (rustbgpd v0.63.0 removed the previous explicit legacy-enforcement configuration). Setting `RUSTBGPD_EVENT_HISTORY_OFF=1` disables the daemon's default-on durable event history for a run.

**Harness fixes** (separate commit):
- The neighbor-stats thread shared one Docker client with the monitor and stats threads, so a state query that blocks under load stalled all of them. It now uses its own client; targets take an optional `dckr_override`. Targets that override `get_neighbor_received_routes()` (frr, flock, srlinux) previously raised `TypeError` here.
- `get_neighbors_state()` returning `(None, None)` now means "query failed" and no longer crashes the stats loop, so a failed query is distinguishable from zero neighbors.
- The monitor's received count is treated as ground truth for convergence. A per-neighbor query returning late used to reset the stabilization counter indefinitely and hang the run.
- The zero-received fast-fail is raised from 15 s to 120 s; slow-booting targets were failed before they could establish.
- `monitor.py wait_established()` is bounded (600 s) and raises a clear error instead of looping forever when the target never accepts the monitor peering.
- The tester's BIRD config drops the redundant `interface "eth0"` pin; strict bind plus an explicit source address already constrain the socket.

**.gitignore**: the checked-in file was the one `python -m venv` generates and ignores every file (`*`), so no new file can be added without `git add -f`. Replaced with targeted ignores.

**Testing**: built the image with `--no-cache` and ran `bench -t rustbgpd` at `-n 10 -p 1000`, `-n 2 -p 10000`, and `-n 2 -p 100000` on a 64-core / 125 GiB Linux host with Docker. All three complete: total time 8.36 s / 8.26 s / 12.18 s, max mem 0.038 / 0.046 / 0.21 GB, target reporting `rustbgpd 0.62.0`, zero failures. After advancing the pin to v0.63.0: rebuilt the image with `--no-cache` and re-ran `bench -t rustbgpd`, converging with the target reporting `rustbgpd 0.63.0`.

Known issue, not addressed here: the openbgp target starts `/usr/local/sbin/bgpd`, but the `openbgpd/openbgpd` image ships its binaries in `/usr/sbin` and its entrypoint already runs bgpd with the image's default neighbor-less config, so the harness-generated config is never loaded and the run used to hang in `wait_established()` (it now fails after the timeout). A correct fix needs the target restructured around the image entrypoint, so it is left for a separate change.

